### PR TITLE
Fix RemovedInDjango40 error

### DIFF
--- a/multi_email_field/forms.py
+++ b/multi_email_field/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from multi_email_field.widgets import MultiEmailWidget
 


### PR DESCRIPTION
The owner of the `django-multi-email-field` repo hasn't replied back to issues that have been pending for almost 2 years so forking the repo and making the required changes on our end. Once the original repo is updated we can transfer back to that package.